### PR TITLE
Port unit tests to JUnit 5

### DIFF
--- a/knotx-stack-manager/pom.xml
+++ b/knotx-stack-manager/pom.xml
@@ -138,13 +138,12 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.3.0</version>
+      <version>3.11.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
   </dependencies>
 
@@ -153,7 +152,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.0</version>
         <configuration>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>
@@ -161,6 +160,18 @@
             </vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>1.2.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.2.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>

--- a/knotx-stack-manager/pom.xml
+++ b/knotx-stack-manager/pom.xml
@@ -228,7 +228,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/DescriptorTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/DescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ *  Copyright (c) 2011-2018 The original author or authors
  *  ------------------------------------------------------
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/DescriptorTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/DescriptorTest.java
@@ -18,21 +18,20 @@
 
 package io.knotx.stack;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.jayway.awaitility.Awaitility;
+import io.knotx.stack.command.ResolveCommand;
+import io.knotx.stack.utils.FileUtils;
 import io.vertx.core.Launcher;
 import io.vertx.core.impl.launcher.VertxCommandLauncher;
 import io.vertx.core.spi.launcher.ExecutionContext;
-import io.knotx.stack.command.ResolveCommand;
-import io.knotx.stack.utils.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -42,7 +41,7 @@ public class DescriptorTest {
 
   private File root = new File("target/stack");
 
-  @Before
+  @BeforeEach
   public void setUp() {
     FileUtils.delete(root);
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !root.exists());

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/StackResolutionTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/StackResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ *  Copyright (c) 2011-2018 The original author or authors
  *  ------------------------------------------------------
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/VertxStacksTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/VertxStacksTest.java
@@ -27,24 +27,24 @@ import io.vertx.core.impl.launcher.commands.VersionCommand;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class VertxStacksTest {
 
   private File root = new File("target/stack");
 
-  @Before
+  @BeforeEach
   public void setUp() {
     FileUtils.delete(root);
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !root.exists());
-    String vertxVersion = new VersionCommand().getVersion();
+    String vertxVersion = VersionCommand.getVersion();
     assertThat(vertxVersion).isNotEmpty();
     System.setProperty("vertx.version", vertxVersion);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.clearProperty("knotx.version");
   }

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/VertxStacksTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/VertxStacksTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ *  Copyright (c) 2011-2018 The original author or authors
  *  ------------------------------------------------------
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/resolver/ResolverTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/resolver/ResolverTest.java
@@ -17,19 +17,18 @@
 package io.knotx.stack.resolver;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.knotx.stack.utils.FileUtils;
 import io.knotx.stack.utils.LocalArtifact;
 import io.knotx.stack.utils.LocalDependency;
 import io.knotx.stack.utils.LocalRepoBuilder;
-import org.eclipse.aether.artifact.Artifact;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.aether.artifact.Artifact;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -42,7 +41,7 @@ public class ResolverTest {
 
   private Resolver resolver = Resolver.create(new ResolverOptions().setLocalRepository(LOCAL.getAbsolutePath()));
 
-  @Before
+  @BeforeEach
   public void setUp() {
     FileUtils.delete(LOCAL);
   }

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/utils/CacheTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/utils/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ *  Copyright (c) 2011-2018 The original author or authors
  *  ------------------------------------------------------
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/utils/CacheTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/utils/CacheTest.java
@@ -16,20 +16,20 @@
 
 package io.knotx.stack.utils;
 
-import io.knotx.stack.resolver.ResolutionOptions;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import io.knotx.stack.resolver.ResolutionOptions;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -39,9 +39,10 @@ public class CacheTest {
   private Cache cache;
   private File cacheFile;
 
-  static File TEMP_FILE;
+  private static File TEMP_FILE;
 
-  static {
+  @BeforeAll
+  public static void classSetUp() {
     try {
       TEMP_FILE = File.createTempFile("acme", ".jar");
     } catch (IOException e) {
@@ -49,8 +50,10 @@ public class CacheTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    assertThat(TEMP_FILE).exists();
+
     cacheFile = new File("target/test-cache/cache.json");
     if (cacheFile.isFile()) {
       cacheFile.delete();
@@ -61,7 +64,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingOfReleaseAndUpdate() throws IOException {
+  public void testCachingOfReleaseAndUpdate() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -84,7 +87,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingOfSnapshotAndUpdate() throws IOException {
+  public void testCachingOfSnapshotAndUpdate() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -124,7 +127,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testCacheDisabledForSnapshots() throws IOException {
+  public void testCacheDisabledForSnapshots() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     cache = new Cache(false, true, cacheFile);
     ResolutionOptions options = new ResolutionOptions();
@@ -139,7 +142,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testWithInvalidArtifact() throws IOException {
+  public void testWithInvalidArtifact() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -153,7 +156,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testWithEmptyResolution() throws IOException {
+  public void testWithEmptyResolution() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -164,7 +167,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testCacheReloading() throws IOException {
+  public void testCacheReloading() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -184,7 +187,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testSnapshotEviction() throws IOException {
+  public void testSnapshotEviction() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -204,7 +207,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testNonSnapshotEviction() throws IOException {
+  public void testNonSnapshotEviction() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -224,7 +227,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingUsingDifferentResolutionOption() throws IOException {
+  public void testCachingUsingDifferentResolutionOption() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/utils/FilteringTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/utils/FilteringTest.java
@@ -16,16 +16,16 @@
 
 package io.knotx.stack.utils;
 
-import org.junit.Test;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.Collections;
-
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import org.junit.jupiter.api.Test;
 
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
+@SuppressWarnings("unchecked")
 public class FilteringTest {
 
   @Test

--- a/knotx-stack-manager/src/test/java/io/knotx/stack/utils/FilteringTest.java
+++ b/knotx-stack-manager/src/test/java/io/knotx/stack/utils/FilteringTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ *  Copyright (c) 2011-2018 The original author or authors
  *  ------------------------------------------------------
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
- Switch to JUnit 5, include explicit dependencies for surefire plugin (otherwise tests will fail)
- Updated AssertJ version (maybe it should get its own dependency in `knotx-dependencies`?)

Preliminary for Cognifide/knotx#433.

~~Travis currently fails, fix incoming.~~