### PR TITLE
Add Knot.x Forms to stack manager

### DIFF
--- a/knotx-it-tests/pom.xml
+++ b/knotx-it-tests/pom.xml
@@ -48,6 +48,14 @@
     </dependency>
     <dependency>
       <groupId>io.knotx</groupId>
+      <artifactId>knotx-forms-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.knotx</groupId>
+      <artifactId>knotx-forms-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.knotx</groupId>
       <artifactId>knotx-knot-service</artifactId>
     </dependency>
     <dependency>

--- a/knotx-stack-manager/src/main/descriptor/knotx-stack.json
+++ b/knotx-stack-manager/src/main/descriptor/knotx-stack.json
@@ -63,6 +63,19 @@
       "version": "\${knotx.version}",
       "included": true
     },
+    // Knot.x Forms
+    {
+      "groupId": "io.knotx",
+      "artifactId": "knotx-forms-api",
+      "version": "\${knotx.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.knotx",
+      "artifactId": "knotx-forms-core",
+      "version": "\${knotx.version}",
+      "included": true
+    },
     // Vert.x dependencies
     {
       "groupId": "io.vertx",


### PR DESCRIPTION
Add Knotx Forms modules to stack manager. Changes should be applied after releasing [knotx-forms](https://github.com/Knotx/knotx-forms).