### PR TITLE
Extract assembler and splitter EB addresses to globals.

### DIFF
--- a/knotx-stack-manager/src/main/packaging/conf/application.conf
+++ b/knotx-stack-manager/src/main/packaging/conf/application.conf
@@ -37,13 +37,15 @@ global {
     paramsPrefix = data-knotx-
   }
 
+  assembler.address = knotx.core.assembler
+  splitter.address = knotx.core.splitter
+
   repositories {
     httpRepo.address = knotx.core.repository.http
     # fileSystemRepo.address = knotx.core.repository.filesystem
   }
 
-  hbs.address = knotx.knot.handlebars
-
+  # Knot.x Forms
   forms.address = knotx.knot.forms
 
   # Data Bridge globals
@@ -53,6 +55,9 @@ global {
       http.address = knotx.bridge.datasource.http
     }
   }
+
+  # Knot.x Template Engine with Handlebars Syntax
+  hbs.address = knotx.knot.handlebars
 }
 
 ########### Modules configurations ###########
@@ -76,7 +81,7 @@ config.httpRepo {
 
 config.splitter.options.config {
   # Event bus address on which splitter is listening on. Default is 'knotx.core.splitter'
-  # address =
+  address = ${global.splitter.address} # Do not change
 
   # Knot.x snippet options. Configures e.g. HTML tag name (default is 'script') and snippet
   # params prefix (default is "data-knotx-")
@@ -85,7 +90,7 @@ config.splitter.options.config {
 
 config.assembler.options.config {
   # Event bus address on which splitter is listening on. Default is 'knotx.core.assembler'
-  # address =
+  address = ${global.assembler.address} # Do not change
 
   # Knot.x snippet options. Configures e.g. HTML tag name (default is 'script') and snippet
   # params prefix (default is "data-knotx-")

--- a/knotx-stack-manager/src/main/packaging/conf/includes/server.conf
+++ b/knotx-stack-manager/src/main/packaging/conf/includes/server.conf
@@ -89,10 +89,10 @@ defaultFlow {
     }
   ]
   # Event bus address of the Fragment splitter. Default is 'knotx.core.splitter'
-  # splitter =
+  splitter = ${global.splitter.address} # Do not change
 
   # Event bus address of the Fragment assembler. Default is 'knotx.core.assembler'
-  # assembler =
+  assembler = ${global.assembler.address} # Do not change
 
   # Here you can define set of routing rules for Knot processing.
   # Keep in mind that the order is important, so the most specific definitions for a given path


### PR DESCRIPTION
Configuration cleanup.

## Description
Extract assembler and splitter EB addresses to globals.

## Motivation and Context
Assembler & Splitter address used in two places - it was not clear without variables in globals.

## Upgrade notes (if appropriate)
No changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
