### PR TITLE
Upgrade to Vert.x 3.8.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,29 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-58](https://github.com/Knotx/knotx-stack/pull/58) - Vert.x upgrade to 3.8.1.
+
+## 2.0.0
+- [PR-55](https://github.com/Knotx/knotx-stack/pull/55) - Update `fragmentsProviderHtmlSplitter` to `htmlFragmentsSupplier` and `fragmentsAssemblerHandler` to `fragmentsAssembler`.
+- [PR-53](https://github.com/Knotx/knotx-stack/pull/53) - Enable [Configurable Integrations](http://knotx.io/blog/configurable-integrations/) for API Gateway.
+- [PR-52](https://github.com/Knotx/knotx-stack/pull/52) - Switch to [Knot.x Gradle Plugins](https://github.com/Knotx/knotx-gradle-plugins).
+- [PR-51](https://github.com/Knotx/knotx-stack/pull/51) - Moving Splitter and Assembler to [Fragments](https://github.com/Knotx/knotx-fragments) repository.
+- [PR-49](https://github.com/Knotx/knotx-stack/pull/49) - Operations configuration file name updated.
+- [PR-48](https://github.com/Knotx/knotx-stack/pull/48) - Build the Knot.x distribution with Gradle.
+- [PR-47](https://github.com/Knotx/knotx-stack/pull/47) - Apply Gradle composite builds.
+- [PR-46](https://github.com/Knotx/knotx-stack/pull/46) - Adjust to new TE configuration entries.
+- [PR-45](https://github.com/Knotx/knotx-stack/pull/45) - Integration tests for `inline-body` and `inline-payload` actions, circuit breaker timeout validation.
+- [PR-43](https://github.com/Knotx/knotx-stack/pull/43) - Integration tests that use Tasks & Actions and the new Data Bridge HTTP Action.
+- [PR-41](https://github.com/Knotx/knotx-stack/pull/41) - Migrate to [Fragments Handler](https://github.com/Knotx/knotx-fragments) implementation. 
+- [PR-39](https://github.com/Knotx/knotx-stack/pull/39) - Knot.x 2.0 Stack & Unit tests.
+- [PR-30](https://github.com/Knotx/knotx-stack/pull/30) - Milestone OpenAPI 3.0.
+
+## 1.5.0
 - [PR-48](https://github.com/Knotx/knotx-stack/pull/48) - Build the Knot.x distribution with Gradle.
 - [PR-36](https://github.com/Knotx/knotx-stack/pull/36) - Cleanup integration tests
+- [PR-35](https://github.com/Knotx/knotx-stack/pull/35) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) - integration tests
 - [PR-32](https://github.com/Knotx/knotx-stack/pull/32) - Extract assembler and splitter EB addresses to globals.
 - [PR-33](https://github.com/Knotx/knotx-stack/pull/33) - Knot.x Template Engine introduced instead of HBS Knot
-- [PR-35](https://github.com/Knotx/knotx-stack/pull/35) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) - integration tests
 
 ## 1.4.0
 - [PR-5](https://github.com/Knotx/knotx-stack/pull/5) - Knot.x Data Bridge introduced instead of Service Knot

--- a/out/test/resources/conf/application.conf
+++ b/out/test/resources/conf/application.conf
@@ -1,0 +1,11 @@
+########### Modules to start ###########
+# Modules map specify a list of verticles to be started by Knot.x.
+# Each line should have a form of <alias>=<verticle-class-name>
+# where alias is just a name that you can use later in order to define configuration for the module
+# verticle-class-name is a fully qualified class name of the verticle.
+#
+# This JSON object is filled in included files.
+modules {}
+
+include required(classpath("conf/server.conf"))
+include required(classpath("conf/knots/templateEngineStack.conf"))

--- a/out/test/resources/conf/knots/templateEngineKnot.conf
+++ b/out/test/resources/conf/knots/templateEngineKnot.conf
@@ -1,0 +1,26 @@
+# Vert.x event bus delivery options used when communicating with other verticles
+address = knotx.knot.te.handlebars
+
+engine {
+  factory = handlebars
+  config = {
+    # Algorithm used to build a hash key of the compiled handlebars snippets.
+    # The hash is computed for the snippet handlebars source code using a selected algorithm.
+    # The name should be a standard Java Security name (such as "SHA", "MD5", and so on).
+    # Default value is MD5
+    #
+    # cacheKeyAlgorithm = MD5
+
+    # Size of the compiled snippets cache. After reaching the max size, new elements will replace the oldest one.
+    cacheSize = 1000
+
+    # Symbol used as a start delimiter of handlebars expression. If not use, a default '{{' is used
+    #
+    # startDelimiter =
+
+    # Symbol used as a end delimiter of handlebars expression. If not use, a default '}}' is used
+    #
+    # endDelimiter =
+  }
+}
+

--- a/out/test/resources/conf/knots/templateEngineStack.conf
+++ b/out/test/resources/conf/knots/templateEngineStack.conf
@@ -1,0 +1,11 @@
+########### Template Engine Stack ###########
+modules {
+  templateEngine = "io.knotx.te.core.TemplateEngineKnot"
+}
+
+########### Modules configurations ###########
+config.templateEngine {
+  options.config {
+    include required(classpath("conf/knots/templateEngineKnot.conf"))
+  }
+}

--- a/out/test/resources/conf/routes/author-info-operation.conf
+++ b/out/test/resources/conf/routes/author-info-operation.conf
@@ -1,0 +1,23 @@
+routingOperations = ${routingOperations} [
+  {
+    operationId = author-info
+    handlers = ${config.server.handlers.common.request} [
+      {
+        name = singleFragmentSupplier
+        config = {
+          type = json
+          configuration {
+            data-knotx-task = author-info-api
+          }
+        }
+      },
+      {
+        name = fragmentsHandler
+        config = ${global.handler.fragmentsHandler.config}
+      },
+      {
+        name = fragmentsAssembler
+      }
+    ] ${config.server.handlers.common.response}
+  }
+]

--- a/out/test/resources/conf/routes/handlers/fragmentsHandler.conf
+++ b/out/test/resources/conf/routes/handlers/fragmentsHandler.conf
@@ -1,0 +1,34 @@
+########### This configuration is overloaded in integration tests! ###########
+tasks {
+  author-listing {
+    action = author
+    onTransitions {
+      _success {
+        action = te-hbs
+      }
+    }
+  }
+}
+
+actions {
+  author {
+    factory = http
+    config {
+      endpointOptions {
+        path = /service/mock/author.json
+        domain = localhost
+        port = ${test.wiremock.mockService.port}
+        allowedRequestHeaders = [ "Content-Type" ]
+      }
+    }
+  }
+  te-hbs {
+    factory = "knot"
+    config {
+      address = "knotx.knot.te.handlebars"
+      deliveryOptions {
+        sendTimeout = 3000
+      }
+    }
+  }
+}

--- a/out/test/resources/conf/routes/handlers/httpRepoConnectorHandler.conf
+++ b/out/test/resources/conf/routes/handlers/httpRepoConnectorHandler.conf
@@ -1,0 +1,62 @@
+# Vert.x event bus delivery options used when communicating with other verticles
+# see http://vertx.io/docs/vertx-core/dataobjects.html#HttpClientOptions for the details what can be configured
+#
+clientOptions {
+  maxPoolSize = 1000
+  idleTimeout = 120 # seconds
+  tryUseCompression = true
+
+  # If you're going to use SSL (clientDestination.scheme='https') then here you'd need to configure
+  # some aspects related to the SSL negotiation and validation.
+  #
+  # Whether all server certificated should be trusted or not (e.g. self-signed certificates)
+  # trustAll = true
+  #
+  # Hostname verification
+  # verifyHost = false
+  #
+  # It will force SSL SNI (Server Name Indication). The SNI will be set to the same value as 'hostHeader' (set in ClientDestination)
+  # forceSni = true
+}
+
+# HTTP Repository connection details
+clientDestination {
+  # Connection scheme: http or https
+  scheme = http
+
+  # domain or the IP of the host: e.g. localhost, 10.0.11.2
+  domain = localhost
+
+  ## Port on which the host listens, e.g. 8080, 3001, etc.
+  port = ${test.wiremock.mockRepository.port}
+
+  # Host header override to be used with a communication to the repository. If it's set, it overrides any value in the 'Host' header, and sets the SNI SSL to the same value.
+  # hostHeader =
+}
+
+# List of allowed request headers that will be send to HTTP repository.
+# Each item is a string that defines regex, e.g. to match any char use `.*`
+#
+allowedRequestHeaders = [
+  Host
+  "Accept.*"
+  Authorization
+  Connection
+  Cookie
+  Date
+  "Edge.*"
+  "If.*"
+  Origin
+  Pragma
+  Proxy-Authorization
+  "Surrogate.*"
+  User-Agent
+  Via
+  "X-.*"
+]
+
+# Statically defined HTTP request header sent in every request to the repository
+customHttpHeader = {
+  name = X-User-Agent
+  value = Knot.x
+}

--- a/out/test/resources/conf/routes/te-get.conf
+++ b/out/test/resources/conf/routes/te-get.conf
@@ -1,0 +1,21 @@
+routingOperations = ${routingOperations} [
+  {
+    operationId = te-get
+    handlers = ${config.server.handlers.common.request} [
+      {
+        name = httpRepoConnectorHandler
+        config = ${global.handler.httpRepoConnectorHandler.config}
+      },
+      {
+        name = htmlFragmentsSupplier
+      },
+      {
+        name = fragmentsHandler
+        config = ${global.handler.fragmentsHandler.config}
+      },
+      {
+        name = fragmentsAssembler
+      }
+    ] ${config.server.handlers.common.response}
+  }
+]

--- a/out/test/resources/conf/server.conf
+++ b/out/test/resources/conf/server.conf
@@ -1,0 +1,101 @@
+########### Knot.x JUnit5 config ###########
+test {
+  random {
+    globalServer.port = 0
+  }
+}
+
+########### Knot.x Server ###########
+modules {
+  server = "io.knotx.server.KnotxServerVerticle"
+}
+
+########### Modules configurations ###########
+config.server {
+  handlers.common {
+    request = [
+      {
+        name = bodyHandler
+      },
+      {
+        name = requestContextHandler
+      }
+    ],
+    response = [
+      {
+        name = headerHandler
+        # Statically defined HTTP response header returned to the client in every HTTP response
+        config {
+          name = X-Server
+          value = Knot.x-Custom-Header
+        }
+      },
+      {
+        name = writerHandler
+        # List of HTTP response headers Knot.x can return to the client
+        config.allowedResponseHeaders = [
+          Access-Control-Allow-Origin
+          Content-Type
+          Content-Length
+          X-Server
+        ]
+      }
+    ]
+  }
+  options.config {
+    # Configuraiton of HTTP server
+    serverOptions {
+      # Knot.x server HTTP port
+      port = ${test.random.globalServer.port}
+
+      # If you want a server to serve SSL connections you can configure it here
+      #
+      # Enable SSL
+      # ssl = true
+      #
+      # Path on the server the keystore.jks file is located
+      # keyStoreOptions.path =
+      #
+      # Keystore password
+      # keyStoreOptions.password =
+    }
+
+    # Location of your Open API spec. It can be an absolute path, a local path or remote url (with HTTP protocol).
+    routingSpecificationLocation = /openapi.yaml
+
+    displayExceptionDetails = true
+
+    dropRequestOptions {
+      # FixMe this should be enabled by default, see https://github.com/Knotx/knotx-server-http/issues/20 for details
+      enabled = false
+
+      # Status code that is served if the response is dropped, default is 429, "Too Many Requests"
+      # dropRequestResponseCode =
+
+      # Number of request that single Server insance can support concurrently. Default value is 1000.
+      # backpressureBufferCapacity
+
+      # Strategy how to deal with backpressure buffer overflow. Default is DROP_LATEST.
+      # backpressureStrategy =
+    }
+
+    routingOperations = []
+    include required(classpath("conf/routes/te-get.conf"))
+    include required(classpath("conf/routes/author-info-operation.conf"))
+  }
+
+  # The options object carries-on configuration called DeploymentOptions for a given verticle.
+  # It allows you to control the verticle behaviour, such as how many instances, classpath isolation, workers, etc.
+  # See available options http://vertx.io/docs/vertx-core/dataobjects.html#DeploymentOptions
+  #
+  # options {}
+}
+
+########### Globals ###########
+global {
+  handler {
+    httpRepoConnectorHandler.config = { include required(classpath("conf/routes/handlers/httpRepoConnectorHandler.conf")) }
+    # This value is overloaded in test
+    fragmentsHandler.config = { include required(classpath("conf/routes/handlers/fragmentsHandler.conf")) }
+  }
+}

--- a/out/test/resources/conf/tasks/task-with-fallback-action.conf
+++ b/out/test/resources/conf/tasks/task-with-fallback-action.conf
@@ -1,0 +1,89 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    tags-listing {
+      action = tags
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+        _error {
+          action = tags-fallback
+        }
+      }
+    }
+    authors-listing {
+      action = author
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+      }
+    }
+    books-and-authors-listing {
+      actions = [
+        {
+          action = book
+        },
+        {
+          action = author
+        }
+      ]
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+      }
+    }
+  }
+
+  actions {
+    tags {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/broken/500.json
+          domain = localhost
+          port = ${test.wiremock.mockBrokenService.port}
+          allowedRequestHeaders = [ "Content-Type" ]
+        }
+      }
+    }
+    tags-fallback {
+      factory = inline-body
+      config {
+        body = """<p>Tags are unavailable at the moment</p>"""
+      }
+    }
+    book {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/book.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    author {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/author.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = [ "Content-Type" ]
+        }
+      }
+    }
+    te-hbs {
+      factory = "knot"
+      config {
+        address = "knotx.knot.te.handlebars"
+        deliveryOptions {
+          sendTimeout = 3000
+        }
+      }
+    }
+  }
+}

--- a/out/test/resources/content/brokenService.html
+++ b/out/test/resources/content/brokenService.html
@@ -1,0 +1,31 @@
+<!--
+  Copyright (C) 2018 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Broken service</title>
+</head>
+<body>
+  <div>
+  <knotx:snippet data-knotx-task="templating"
+                 databridge-name="broken">
+    <h2>I'm still working!</h2>
+    <p>Status code: {{_response.statusCode}}</p>
+  </knotx:snippet>
+  </div>
+</body>
+</html>

--- a/out/test/resources/content/fullPage.html
+++ b/out/test/resources/content/fullPage.html
@@ -1,0 +1,84 @@
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/4/simplex/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="jumbotron">
+        <h2>
+          Hello Knot.x - reactive micro-service assembler world!
+        </h2>
+        <p>
+          This template is served from the <strong>local</strong> repository.
+        </p>
+        <p>
+          <a class="btn btn-primary btn-large"
+             href="https://github.com/Knotx/knotx">Learn more</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <knotx:snippet data-knotx-task="books-and-authors-listing">
+      <div class="col-md-4">
+        <h2>Book</h2>
+        <p>{{book._result.title}}</p>
+        <p>Authors: {{book._result.info.authors}}</p>
+        <div>Success! Status code : {{book._response.metadata.statusCode}}</div>
+      </div>
+      <div class="col-md-4">
+        <h2>Author</h2>
+        <p>{{author._result.name}}</p>
+        <p>Bio: {{author._result.info.bio}}</p>
+        <div>Success! Status code : {{author._response.metadata.statusCode}}</div>
+      </div>
+    </knotx:snippet>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <knotx:snippet data-knotx-task="authors-listing">
+        <h2>Portfolio: </h2>
+        <ul>
+          {{#each author._result.info.portfolio}}
+          <li>{{this}}</li>
+          {{/each}}
+        </ul>
+      </knotx:snippet>
+    </div>
+    <div class="col-md-4">
+      <knotx:snippet data-knotx-task="books-listing">
+        <h2>Tags: </h2>
+        <ul>
+          {{#each book._result.info.tags}}
+          <li>{{this}}</li>
+          {{/each}}
+        </ul>
+      </knotx:snippet>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/out/test/resources/logback-test.xml
+++ b/out/test/resources/logback-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration debug="true">
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
+
+  <include resource="io/knotx/logging/logback/defaults.xml"/>
+  <include resource="io/knotx/logging/logback/console-appender.xml"/>
+
+  <logger name="io.knotx" level="TRACE"/>
+  <logger name="io.vertx" level="TRACE"/>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/out/test/resources/openapi.yaml
+++ b/out/test/resources/openapi.yaml
@@ -1,0 +1,51 @@
+#  Copyright (C) 2019 Knot.x Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Knot.x Stack OAS
+  description: This is a full flow server used during integration tests.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+- url: https://{domain}:{port}
+  description: The local API server
+  variables:
+    domain:
+      default: localhost
+      description: api domain
+    port:
+      enum:
+        - '8092'
+        - '443'
+      default: '8092'
+
+paths:
+  /content/*:
+    get:
+      operationId: te-get
+      responses:
+        default:
+          description: HTTP repository response continaing fragments with
+            Data Bridge (https://github.com/Knotx/knotx-data-bridge) and
+            Template Engine (https://github.com/Knotx/knotx-template-engine) processing
+  /api/author-info:
+    get:
+      operationId: author-info
+      responses:
+        default:
+          description: Gateway API endpoint that uses Data Bridge (https://github.com/Knotx/knotx-data-bridge)

--- a/out/test/resources/results/brokenService.html
+++ b/out/test/resources/results/brokenService.html
@@ -1,0 +1,28 @@
+<!--
+  Copyright (C) 2018 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Broken service</title>
+</head>
+<body>
+  <div>
+    <h2>I'm still working!</h2>
+    <p>Status code: {{_response.statusCode}}</p>
+  </div>
+</body>
+</html>

--- a/out/test/resources/results/fullPage.html
+++ b/out/test/resources/results/fullPage.html
@@ -1,0 +1,71 @@
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/superhero/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="jumbotron">
+          <h2> Hello Knot.x - reactive micro-service assembler world! </h2>
+          <p> This template is served from the <strong>local</strong> repository. </p>
+          <p> <a class="btn btn-primary btn-large" href="https://github.com/Knotx/knotx">Learn more</a> </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <h2>Book</h2>
+        <p>Knot.x Integration Tests in Practice</p>
+        <p>Authors: Knot.x Team</p>
+        <div>Success! Status code : 200</div>
+      </div>
+      <div class="col-md-4">
+        <h2>Author</h2>
+        <p>Knot X</p>
+        <p>Bio: Aliquam cursus fermentum mi, vel tempus mi pellentesque vel. Nunc in feugiat lorem. Etiam placerat ante eget sem euismod, sit amet dictum sapien vulputate. Morbi pellentesque arcu a mauris ornare eleifend.</p>
+        <div>Success! Status code : 200</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <h2>Portfolio: </h2>
+        <ul>
+          <li>tutorials</li>
+          <li>blogs</li>
+          <li>books</li>
+        </ul>
+      </div>
+      <div class="col-md-4">
+        <h2>Tags: </h2>
+        <ul>
+          <li>reactive</li>
+          <li>integration</li>
+          <li>framework</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/out/test/resources/scenarios/failing-http-services-with-fallbacks/mocks.conf
+++ b/out/test/resources/scenarios/failing-http-services-with-fallbacks/mocks.conf
@@ -1,0 +1,8 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}
+test.random {
+  mockBrokenService.port = 0
+}

--- a/out/test/resources/scenarios/failing-http-services-with-fallbacks/result/fullPage.html
+++ b/out/test/resources/scenarios/failing-http-services-with-fallbacks/result/fullPage.html
@@ -1,0 +1,66 @@
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/superhero/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="jumbotron">
+          <h2> Hello Knot.x - reactive micro-service assembler world! </h2>
+          <p> This template is served from the <strong>local</strong> repository. </p>
+          <p> <a class="btn btn-primary btn-large" href="https://github.com/Knotx/knotx">Learn more</a> </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <h2>Book</h2>
+        <p>Knot.x Integration Tests in Practice</p>
+        <p>Authors: Knot.x Team</p>
+        <div>Success! Status code : 500</div>
+      </div>
+      <div class="col-md-4">
+        <h2>Author</h2>
+        <p>Knot X</p>
+        <p>Bio: Aliquam cursus fermentum mi, vel tempus mi pellentesque vel. Nunc in feugiat lorem. Etiam placerat ante eget sem euismod, sit amet dictum sapien vulputate. Morbi pellentesque arcu a mauris ornare eleifend.</p>
+        <div>Success! Status code : 500</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <h2>Portfolio: </h2>
+        <ul>
+          <li>tutorials</li>
+          <li>blogs</li>
+          <li>books</li>
+        </ul>
+      </div>
+      <div class="col-md-4">
+        <p>Tags are unavailable at the moment</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/out/test/resources/scenarios/failing-http-services-with-fallbacks/tasks.conf
+++ b/out/test/resources/scenarios/failing-http-services-with-fallbacks/tasks.conf
@@ -1,0 +1,133 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    books-listing {
+      action = book
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+        _error {
+          action = book-inline-body-fallback
+        }
+      }
+    }
+    authors-listing {
+      action = author
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+        _error {
+          action = author-inline-payload-fallback
+          onTransitions._success {
+            action = te-hbs
+          }
+        }
+      }
+    }
+    books-and-authors-listing {
+      actions = [
+        {
+          action = book
+          onTransitions._error {
+            action = book-inline-payload-fallback
+          }
+        },
+        {
+          action = author
+        }
+      ]
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+        _error {
+          action = author-inline-payload-fallback
+          onTransitions._success {
+            action = te-hbs
+          }
+        }
+      }
+    }
+  }
+
+  actions {
+    book {
+      factory = http
+      config.endpointOptions {
+        path = /service/broken/500.json
+        domain = localhost
+        port = ${test.random.mockBrokenService.port}
+        allowedRequestHeaders = ["Content-Type"]
+      }
+    }
+    author {
+      factory = http
+      config.endpointOptions {
+        path = /service/broken/500.json
+        domain = localhost
+        port = ${test.wiremock.mockService.port}
+        allowedRequestHeaders = ["Content-Type"]
+      }
+    }
+    te-hbs {
+      factory = knot
+      config {
+        address = knotx.knot.te.handlebars
+        deliveryOptions {
+          sendTimeout = 3000
+        }
+      }
+    }
+    // fallbacks
+    author-inline-payload-fallback {
+      factory = inline-payload
+      config {
+        alias = author
+        payload {
+          _result {
+            name = "Knot X",
+            info {
+              portfolio = [
+                "tutorials",
+                "blogs",
+                "books"
+              ],
+              bio = "Aliquam cursus fermentum mi, vel tempus mi pellentesque vel. Nunc in feugiat lorem. Etiam placerat ante eget sem euismod, sit amet dictum sapien vulputate. Morbi pellentesque arcu a mauris ornare eleifend."
+            }
+          }
+          _response {
+            metadata {
+              statusCode = 500
+            }
+          }
+        }
+      }
+    }
+    book-inline-payload-fallback {
+      factory = inline-payload
+      config {
+        alias = book
+        payload {
+          _result {
+            title = "Knot.x Integration Tests in Practice"
+            info {
+              authors = "Knot.x Team"
+            }
+          }
+          _response {
+            metadata {
+              statusCode = 500
+            }
+          }
+        }
+      }
+    }
+    book-inline-body-fallback {
+      factory = inline-body
+      config {
+        body = "<p>Tags are unavailable at the moment</p>"
+      }
+    }
+  }
+}

--- a/out/test/resources/scenarios/gateway-api-with-fragments/mocks.conf
+++ b/out/test/resources/scenarios/gateway-api-with-fragments/mocks.conf
@@ -1,0 +1,8 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}
+test.random {
+  mockBrokenService.port = 0
+}

--- a/out/test/resources/scenarios/gateway-api-with-fragments/result/author-info.json
+++ b/out/test/resources/scenarios/gateway-api-with-fragments/result/author-info.json
@@ -1,0 +1,10 @@
+{
+  "dateOfBirth": 2016,
+  "portfolio": [
+    "tutorials",
+    "blogs",
+    "books"
+  ],
+  "bio": "Aliquam cursus fermentum mi, vel tempus mi pellentesque vel. Nunc in feugiat lorem. Etiam placerat ante eget sem euismod, sit amet dictum sapien vulputate. Morbi pellentesque arcu a mauris ornare eleifend."
+}
+

--- a/out/test/resources/scenarios/gateway-api-with-fragments/tasks.conf
+++ b/out/test/resources/scenarios/gateway-api-with-fragments/tasks.conf
@@ -1,0 +1,30 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    author-info-api {
+      action = author
+      onTransitions._success {
+        action = author-info-to-body
+      }
+    }
+  }
+
+  actions {
+    author {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/author.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    author-info-to-body {
+      factory = payload-to-body
+      config {
+        key = author._result.info
+      }
+    }
+  }
+}

--- a/out/test/resources/scenarios/http-service/mocks.conf
+++ b/out/test/resources/scenarios/http-service/mocks.conf
@@ -1,0 +1,5 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}

--- a/out/test/resources/scenarios/http-service/tasks.conf
+++ b/out/test/resources/scenarios/http-service/tasks.conf
@@ -1,0 +1,78 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    books-listing {
+      action = book
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+      }
+    }
+    authors-listing {
+      action = author
+      onTransitions._success {
+        action = te-hbs
+      }
+    }
+    books-and-authors-listing {
+      actions = [
+        {
+          action = book
+        },
+        {
+          action = author
+        }
+      ]
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+      }
+    }
+  }
+
+  actions {
+    tags {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/tags.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    book {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/book.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    author {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/author.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    te-hbs {
+      factory = knot
+      config {
+        address = knotx.knot.te.handlebars
+        deliveryOptions {
+          sendTimeout = 3000
+        }
+      }
+    }
+  }
+}

--- a/out/test/resources/scenarios/long-running-http-service-with-circuit-breaker/mocks.conf
+++ b/out/test/resources/scenarios/long-running-http-service-with-circuit-breaker/mocks.conf
@@ -1,0 +1,8 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}
+test.random {
+  delayedService.port = 0
+}

--- a/out/test/resources/scenarios/long-running-http-service-with-circuit-breaker/result/fullPage.html
+++ b/out/test/resources/scenarios/long-running-http-service-with-circuit-breaker/result/fullPage.html
@@ -1,0 +1,66 @@
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/superhero/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="jumbotron">
+          <h2> Hello Knot.x - reactive micro-service assembler world! </h2>
+          <p> This template is served from the <strong>local</strong> repository. </p>
+          <p> <a class="btn btn-primary btn-large" href="https://github.com/Knotx/knotx">Learn more</a> </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <h2>Book</h2>
+        <p>Knot.x Integration Tests in Practice</p>
+        <p>Authors: Knot.x Team</p>
+        <div>Success! Status code : 500</div>
+      </div>
+      <div class="col-md-4">
+        <h2>Author</h2>
+        <p>Knot X</p>
+        <p>Bio: Aliquam cursus fermentum mi, vel tempus mi pellentesque vel. Nunc in feugiat lorem. Etiam placerat ante eget sem euismod, sit amet dictum sapien vulputate. Morbi pellentesque arcu a mauris ornare eleifend.</p>
+        <div>Success! Status code : 200</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <h2>Portfolio: </h2>
+        <ul>
+          <li>tutorials</li>
+          <li>blogs</li>
+          <li>books</li>
+        </ul>
+      </div>
+      <div class="col-md-4">
+        <p>Tags are unavailable at the moment</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/out/test/resources/scenarios/long-running-http-service-with-circuit-breaker/tasks.conf
+++ b/out/test/resources/scenarios/long-running-http-service-with-circuit-breaker/tasks.conf
@@ -1,0 +1,113 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    books-listing {
+      action = book-with-circuit-breaker
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+        _error {
+          action = book-inline-body-fallback
+        }
+      }
+    }
+    authors-listing {
+      action = author
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+      }
+    }
+    books-and-authors-listing {
+      actions = [
+        {
+          action = book
+          onTransitions._error {
+            action = book-inline-payload-fallback
+          }
+        },
+        {
+          action = author
+        }
+      ]
+      onTransitions {
+        _success {
+          action = te-hbs
+        }
+      }
+    }
+  }
+
+  actions {
+    book-with-circuit-breaker {
+      factory = cb
+      config {
+        circuitBreakerName = "Circuit Breaker: book service"
+        circuitBreakerOptions {
+          timeout = 1000
+          maxFailures = 1
+          resetTimeout = 10000
+        }
+      }
+      doAction = book
+    }
+    book {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/delayed
+          domain = localhost
+          port = ${test.random.delayedService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    author {
+      factory = http
+      config {
+        endpointOptions {
+          path = /service/mock/author.json
+          domain = localhost
+          port = ${test.wiremock.mockService.port}
+          allowedRequestHeaders = [ "Content-Type" ]
+        }
+      }
+    }
+    te-hbs {
+      factory = knot
+      config {
+        address = knotx.knot.te.handlebars
+        deliveryOptions {
+          sendTimeout = 3000
+        }
+      }
+    }
+    // fallbacks
+    book-inline-payload-fallback {
+      factory = inline-payload
+      config {
+        alias = book
+        payload {
+          _result {
+            title = "Knot.x Integration Tests in Practice"
+            info {
+              authors = "Knot.x Team"
+            }
+          }
+          _response {
+            metadata {
+              statusCode = 500
+            }
+          }
+        }
+      }
+    }
+    book-inline-body-fallback {
+      factory = inline-body
+      config {
+        body = "<p>Tags are unavailable at the moment</p>"
+      }
+    }
+  }
+}

--- a/out/test/resources/scenarios/response-headers/mocks.conf
+++ b/out/test/resources/scenarios/response-headers/mocks.conf
@@ -1,0 +1,7 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository {
+    port = 0
+    httpMethods = ""
+  }
+}

--- a/out/test/resources/service/broken/500.json
+++ b/out/test/resources/service/broken/500.json
@@ -1,0 +1,1 @@
+Internal Server Error

--- a/out/test/resources/service/mock/author.json
+++ b/out/test/resources/service/mock/author.json
@@ -1,0 +1,12 @@
+{
+  "name": "Knot X",
+  "info": {
+    "dateOfBirth": 2016,
+    "portfolio": [
+      "tutorials",
+      "blogs",
+      "books"
+    ],
+    "bio": "Aliquam cursus fermentum mi, vel tempus mi pellentesque vel. Nunc in feugiat lorem. Etiam placerat ante eget sem euismod, sit amet dictum sapien vulputate. Morbi pellentesque arcu a mauris ornare eleifend."
+  }
+}

--- a/out/test/resources/service/mock/book.json
+++ b/out/test/resources/service/mock/book.json
@@ -1,0 +1,13 @@
+{
+  "title": "Knot.x Integration Tests in Practice",
+  "info": {
+    "noOfPages": 1337,
+    "authors": "Knot.x Team",
+    "tags": [
+      "reactive",
+      "integration",
+      "framework"
+    ],
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sollicitudin ex vel dictum venenatis. Donec posuere scelerisque tellus vitae posuere. Nullam non tortor eget eros hendrerit convallis. Fusce gravida sit amet nisi a maximus. Integer sed magna semper, rutrum mi eget, volutpat est. Suspendisse et arcu ut purus facilisis lobortis."
+  }
+}

--- a/out/test/resources/service/mock/labelsRepository.json
+++ b/out/test/resources/service/mock/labelsRepository.json
@@ -1,0 +1,6 @@
+{
+  "welcomeInCompetition": "welcome in competition",
+  "thankYouForSubscribingToCompetition": "thank you for subscribing to competition",
+  "subscribeToNewsletter": "subscribe to newsletter",
+  "thankYouForSubscribingToNewsletter": "thank you for subscribing to newsletter"
+}

--- a/out/test/resources/service/mock/tags.json
+++ b/out/test/resources/service/mock/tags.json
@@ -1,0 +1,7 @@
+{
+  "tags": [
+    "reactive",
+    "integration",
+    "framework"
+  ]
+}

--- a/src/main/packaging/conf/server.conf
+++ b/src/main/packaging/conf/server.conf
@@ -8,9 +8,6 @@ config.server {
   handlers.common {
     request = [
       {
-        name = cookieHandler
-      },
-      {
         name = bodyHandler
       },
       {

--- a/src/test/resources/conf/server.conf
+++ b/src/test/resources/conf/server.conf
@@ -15,9 +15,6 @@ config.server {
   handlers.common {
     request = [
       {
-        name = cookieHandler
-      },
-      {
         name = bodyHandler
       },
       {


### PR DESCRIPTION
Upgrade Vert.x from `3.7.1` to `3.8.1`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Upgrade notes (if appropriate)
Cookie Handler is deprecated: cookies are enabled by default and this handler is not required anymore.

`cookieHandler` must be removed from `server.conf`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
