### PR TITLE
Upgrade to Vert.x 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,29 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-58](https://github.com/Knotx/knotx-stack/pull/58) - Vert.x upgrade to 3.8.1.
+
+## 2.0.0
+- [PR-55](https://github.com/Knotx/knotx-stack/pull/55) - Update `fragmentsProviderHtmlSplitter` to `htmlFragmentsSupplier` and `fragmentsAssemblerHandler` to `fragmentsAssembler`.
+- [PR-53](https://github.com/Knotx/knotx-stack/pull/53) - Enable [Configurable Integrations](http://knotx.io/blog/configurable-integrations/) for API Gateway.
+- [PR-52](https://github.com/Knotx/knotx-stack/pull/52) - Switch to [Knot.x Gradle Plugins](https://github.com/Knotx/knotx-gradle-plugins).
+- [PR-51](https://github.com/Knotx/knotx-stack/pull/51) - Moving Splitter and Assembler to [Fragments](https://github.com/Knotx/knotx-fragments) repository.
+- [PR-49](https://github.com/Knotx/knotx-stack/pull/49) - Operations configuration file name updated.
+- [PR-48](https://github.com/Knotx/knotx-stack/pull/48) - Build the Knot.x distribution with Gradle.
+- [PR-47](https://github.com/Knotx/knotx-stack/pull/47) - Apply Gradle composite builds.
+- [PR-46](https://github.com/Knotx/knotx-stack/pull/46) - Adjust to new TE configuration entries.
+- [PR-45](https://github.com/Knotx/knotx-stack/pull/45) - Integration tests for `inline-body` and `inline-payload` actions, circuit breaker timeout validation.
+- [PR-43](https://github.com/Knotx/knotx-stack/pull/43) - Integration tests that use Tasks & Actions and the new Data Bridge HTTP Action.
+- [PR-41](https://github.com/Knotx/knotx-stack/pull/41) - Migrate to [Fragments Handler](https://github.com/Knotx/knotx-fragments) implementation. 
+- [PR-39](https://github.com/Knotx/knotx-stack/pull/39) - Knot.x 2.0 Stack & Unit tests.
+- [PR-30](https://github.com/Knotx/knotx-stack/pull/30) - Milestone OpenAPI 3.0.
+
+## 1.5.0
 - [PR-48](https://github.com/Knotx/knotx-stack/pull/48) - Build the Knot.x distribution with Gradle.
 - [PR-36](https://github.com/Knotx/knotx-stack/pull/36) - Cleanup integration tests
+- [PR-35](https://github.com/Knotx/knotx-stack/pull/35) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) - integration tests
 - [PR-32](https://github.com/Knotx/knotx-stack/pull/32) - Extract assembler and splitter EB addresses to globals.
 - [PR-33](https://github.com/Knotx/knotx-stack/pull/33) - Knot.x Template Engine introduced instead of HBS Knot
-- [PR-35](https://github.com/Knotx/knotx-stack/pull/35) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) - integration tests
 
 ## 1.4.0
 - [PR-5](https://github.com/Knotx/knotx-stack/pull/5) - Knot.x Data Bridge introduced instead of Service Knot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-- [PR-58](https://github.com/Knotx/knotx-stack/pull/58) - Vert.x upgrade to 3.8.1.
+- [PR-59](https://github.com/Knotx/knotx-stack/pull/59) - Vert.x upgrade to 3.8.1.
 
 ## 2.0.0
 - [PR-55](https://github.com/Knotx/knotx-stack/pull/55) - Update `fragmentsProviderHtmlSplitter` to `htmlFragmentsSupplier` and `fragmentsAssemblerHandler` to `fragmentsAssembler`.

--- a/src/main/packaging/conf/server.conf
+++ b/src/main/packaging/conf/server.conf
@@ -8,9 +8,6 @@ config.server {
   handlers.common {
     request = [
       {
-        name = cookieHandler
-      },
-      {
         name = bodyHandler
       },
       {

--- a/src/test/resources/conf/server.conf
+++ b/src/test/resources/conf/server.conf
@@ -15,9 +15,6 @@ config.server {
   handlers.common {
     request = [
       {
-        name = cookieHandler
-      },
-      {
         name = bodyHandler
       },
       {


### PR DESCRIPTION
Upgrade Vert.x from `3.7.1` to `3.8.1`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Upgrade notes (if appropriate)
Cookie Handler is deprecated: cookies are enabled by default and this handler is not required anymore.

`cookieHandler` must be removed from `server.conf`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
