### PR TITLE
Fix unit tests with custom wiremock instance

### DIFF
--- a/src/functionalTest/java/io/knotx/stack/functional/FailingHttpServicesWithFallbacksIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/FailingHttpServicesWithFallbacksIntegrationTest.java
@@ -58,7 +58,7 @@ class FailingHttpServicesWithFallbacksIntegrationTest {
     mockBrokenService.stubFor(get(urlMatching("/service/broken/500.json"))
         .willReturn(
             aResponse()
-                .withHeader("Hello", "World")
+                .withHeader("Content-Type", "application/json")
                 .withStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
         ));
     mockBrokenService.start();

--- a/src/functionalTest/resources/conf/routes/handlers/fragmentsHandler.conf
+++ b/src/functionalTest/resources/conf/routes/handlers/fragmentsHandler.conf
@@ -1,27 +1,10 @@
 ########### This configuration is overloaded in integration tests! ###########
 tasks {
-  author-listing {
-    action = author
-    onTransitions {
-      _success {
-        action = te-hbs
-      }
-    }
-  }
+  # will be extended per unit tests
 }
 
 actions {
-  author {
-    factory = http
-    config {
-      endpointOptions {
-        path = /service/mock/author.json
-        domain = localhost
-        port = ${test.wiremock.mockService.port}
-        allowedRequestHeaders = [ "Content-Type" ]
-      }
-    }
-  }
+  # will be extended per unit tests
   te-hbs {
     factory = "knot"
     config {

--- a/src/functionalTest/resources/scenarios/failing-http-services-with-fallbacks/mocks.conf
+++ b/src/functionalTest/resources/scenarios/failing-http-services-with-fallbacks/mocks.conf
@@ -1,7 +1,6 @@
 ########### Knot.x JUnit5 config ###########
 test.wiremock {
   mockRepository.port = 0
-  mockService.port = 0
 }
 test.random {
   mockBrokenService.port = 0

--- a/src/functionalTest/resources/scenarios/failing-http-services-with-fallbacks/tasks.conf
+++ b/src/functionalTest/resources/scenarios/failing-http-services-with-fallbacks/tasks.conf
@@ -3,9 +3,6 @@ global.handler.fragmentsHandler.config {
     books-listing {
       action = book
       onTransitions {
-        _success {
-          action = te-hbs
-        }
         _error {
           action = book-inline-body-fallback
         }
@@ -14,9 +11,6 @@ global.handler.fragmentsHandler.config {
     authors-listing {
       action = author
       onTransitions {
-        _success {
-          action = te-hbs
-        }
         _error {
           action = author-inline-payload-fallback
           onTransitions._success {
@@ -38,9 +32,6 @@ global.handler.fragmentsHandler.config {
         }
       ]
       onTransitions {
-        _success {
-          action = te-hbs
-        }
         _error {
           action = author-inline-payload-fallback
           onTransitions._success {
@@ -66,7 +57,7 @@ global.handler.fragmentsHandler.config {
       config.endpointOptions {
         path = /service/broken/500.json
         domain = localhost
-        port = ${test.wiremock.mockService.port}
+        port = ${test.random.mockBrokenService.port}
         allowedRequestHeaders = ["Content-Type"]
       }
     }

--- a/src/functionalTest/resources/scenarios/long-running-http-service-with-circuit-breaker/tasks.conf
+++ b/src/functionalTest/resources/scenarios/long-running-http-service-with-circuit-breaker/tasks.conf
@@ -2,13 +2,8 @@ global.handler.fragmentsHandler.config {
   tasks {
     books-listing {
       action = book-with-circuit-breaker
-      onTransitions {
-        _success {
-          action = te-hbs
-        }
-        _error {
-          action = book-inline-body-fallback
-        }
+      onTransitions.fallback {
+        action = book-inline-body-fallback
       }
     }
     authors-listing {
@@ -22,8 +17,8 @@ global.handler.fragmentsHandler.config {
     books-and-authors-listing {
       actions = [
         {
-          action = book
-          onTransitions._error {
+          action = book-with-circuit-breaker
+          onTransitions.fallback {
             action = book-inline-payload-fallback
           }
         },
@@ -48,6 +43,7 @@ global.handler.fragmentsHandler.config {
           timeout = 1000
           maxFailures = 1
           resetTimeout = 10000
+          fallbackOnFailure = true
         }
       }
       doAction = book
@@ -70,7 +66,7 @@ global.handler.fragmentsHandler.config {
           path = /service/mock/author.json
           domain = localhost
           port = ${test.wiremock.mockService.port}
-          allowedRequestHeaders = [ "Content-Type" ]
+          allowedRequestHeaders = ["Content-Type"]
         }
       }
     }


### PR DESCRIPTION
## Description
Manually created WireMock instances were not started for tests. Because of that some tests passed when they should fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
