### PR TITLE
knotx/knotx-fragments#79 Expose task log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-72](https://github.com/Knotx/knotx-stack/pull/72) - knotx/knotx-fragments#79 Configuration changes & functional tests..
 - [PR-69](https://github.com/Knotx/knotx-stack/pull/69) - Circuit breaker: `_fallback` transition && fallback on failure strategy
 
 ## 2.1.0

--- a/scenarios/failing-http-services-with-fallbacks/mocks.conf
+++ b/scenarios/failing-http-services-with-fallbacks/mocks.conf
@@ -1,0 +1,7 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+}
+test.random {
+  mockBrokenService.port = 0
+}

--- a/src/functionalTest/java/io/knotx/stack/functional/ManyHandlebarsSnippetsWithDebugScenarioTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/ManyHandlebarsSnippetsWithDebugScenarioTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.stack.functional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.RandomPort;
+import io.knotx.stack.KnotxServerTester;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.Vertx;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KnotxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+class ManyHandlebarsSnippetsWithDebugScenarioTest {
+
+  @Test
+  @DisplayName("Expect page containing fragment's debug data.")
+  @KnotxApplyConfiguration({"conf/application.conf",
+      "scenarios/many-handlebars-snippets-with-debug/mocks.conf",
+      "scenarios/many-handlebars-snippets-with-debug/tasks.conf"})
+  void requestPage(VertxTestContext context, Vertx vertx,
+      @RandomPort Integer globalServerPort) {
+    // when
+    KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
+    serverTester.testGet(context, vertx, "/content/fullPage.html?debug=true",
+        resp -> {
+          assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
+          String response = resp.bodyAsString();
+          assertNotNull(response);
+
+          String scriptRegexp = "<script data-knotx-id=\"?.*?\" type=\"application/json\">(?<fragmentEventJson>.*?)</script>";
+          Pattern scriptPattern = Pattern.compile(scriptRegexp, Pattern.DOTALL);
+
+          Matcher matcher = scriptPattern.matcher(response);
+          // contains 3 fragments
+          assertTrue(matcher.find());
+          assertTrue(matcher.find());
+          assertTrue(matcher.find());
+          assertFalse(matcher.find());
+        });
+  }
+}

--- a/src/functionalTest/resources/conf/routes/handlers/fragmentsHandler.conf
+++ b/src/functionalTest/resources/conf/routes/handlers/fragmentsHandler.conf
@@ -33,3 +33,15 @@ taskFactories = [
     }
   }
 ]
+
+consumerFactories = [
+  {
+    factory = fragmentHtmlBodyWriter
+    config {
+      condition {
+        param = debug
+      }
+      fragmentTypes = [ "snippet" ]
+    }
+  }
+]

--- a/src/functionalTest/resources/scenarios/many-handlebars-snippets-with-debug/mocks.conf
+++ b/src/functionalTest/resources/scenarios/many-handlebars-snippets-with-debug/mocks.conf
@@ -1,0 +1,5 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}

--- a/src/functionalTest/resources/scenarios/many-handlebars-snippets-with-debug/tasks.conf
+++ b/src/functionalTest/resources/scenarios/many-handlebars-snippets-with-debug/tasks.conf
@@ -1,0 +1,75 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    web-api-test {
+      action = fetch-user-info
+      onTransitions._success {
+        actions = [
+          {
+            action = fetch-payment-providers
+          }
+          {
+            action = fetch-offers
+          }
+        ]
+        onTransitions._success {
+          action = create-response
+        }
+      }
+    }
+  }
+
+  actions {
+    fetch-user-info {
+      factory = http
+      config.endpointOptions {
+        path = /service/mock/userInfo.json
+        domain = localhost
+        port = ${test.wiremock.mockService.port}
+        allowedRequestHeaders = ["Content-Type"]
+      }
+    }
+    fetch-payment-providers {
+      factory = http
+      config.endpointOptions {
+        path = /service/mock/paymentProviders.json
+        domain = localhost
+        port = ${test.wiremock.mockService.port}
+        allowedRequestHeaders = ["Content-Type"]
+      }
+    }
+    fetch-offers {
+      factory = http
+      config.endpointOptions {
+        path = /service/mock/specialOffers.json
+        domain = localhost
+        port = ${test.wiremock.mockService.port}
+        allowedRequestHeaders = ["Content-Type"]
+      }
+      config.responseOptions {
+        forceJson = true
+        predicates = []
+      }
+    }
+    create-response {
+      factory = payload-to-body
+    }
+  }
+
+  taskFactories = [
+    {
+      factory = default
+      config {
+        tasks = ${global.handler.fragmentsHandler.config.tasks}
+        nodeFactories = [
+          {
+            factory = action
+            config.actions = ${global.handler.fragmentsHandler.config.actions}
+          }
+          {
+            factory = subtasks
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/packaging/conf/routes/handlers/fragmentsHandler.conf
+++ b/src/main/packaging/conf/routes/handlers/fragmentsHandler.conf
@@ -28,4 +28,14 @@ taskFactories = [
   }
 ]
 
-
+#consumerFactories = [
+#  {
+#    factory = fragmentHtmlBodyWriter
+#    config {
+#      condition {
+#        param = debug
+#      }
+#      fragmentTypes = [ "snippet" ]
+#    }
+#  }
+#]


### PR DESCRIPTION
Configuration changes & functional tests. It relates to PR - [knotx/knotx-fragments#88](https://github.com/Knotx/knotx-fragments/pull/88).

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

It adds commented consumers configuration:
```
#consumerFactories = [
#  {
#    factory = fragmentHtmlBodyWriter
#    config {
#      condition {
#        param = debug
#      }
#      fragmentTypes = [ "snippet" ]
#    }
#  }
#]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
