### PR TITLE
New HTTP methods functional tests

### DIFF
--- a/src/functionalTest/java/io/knotx/stack/functional/DependentHttpActionsScenarioTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/DependentHttpActionsScenarioTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.stack.functional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.RandomPort;
+import io.knotx.stack.KnotxServerTester;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KnotxExtension.class)
+class DependentHttpActionsScenarioTest {
+
+  private static final String TOKEN = "430sgs4hg0wq3tw00)N(E&GN#s03tgso3t3";
+  private static final String API_KEY = "SEousaebES73task4!@%Tyiq3tgs0%%8#^w#JSNB";
+
+  private static final JsonObject AUTH_SERVICE_RESPONSE = new JsonObject().put("token", TOKEN);
+  private static final JsonObject DATABASE_SERVICE_RESPONSE = new JsonObject()
+      .put("status", "success");
+
+  private static final JsonObject SERVICE_B_REQUIRED_BODY = new JsonObject()
+      .put("id", "tester")
+      .put("authToken", TOKEN)
+      .put("operation", "reloadFromPermanentStorage");
+
+  private KnotxServerTester serverTester;
+
+  @Test
+  @DisplayName("Expect successful response from database service when called with a token from auth service")
+  @KnotxApplyConfiguration({"conf/application.conf",
+      "scenarios/dependent-http-actions-scenario-test/mocks.conf",
+      "scenarios/dependent-http-actions-scenario-test/tasks.conf"})
+  void taskWithManyHttpMethods(VertxTestContext context, Vertx vertx,
+      @RandomPort Integer authServicePort, @RandomPort Integer databaseServicePort,
+      @RandomPort Integer globalServerPort) throws UnsupportedEncodingException {
+    // given
+    setUpAuthServer(authServicePort);
+    setUpDatabaseServer(databaseServicePort);
+
+    setUpServerTester(globalServerPort);
+
+    // when, then
+    serverTester
+        .testGet(context, vertx, "/api/user?id=tester&key=" + encodedApiKey(),
+            this::shouldReturnValidResponse);
+  }
+
+  private void setUpAuthServer(int servicePort) {
+    WireMockServer authServiceServer = new WireMockServer(servicePort);
+    authServiceServer.stubFor(get(urlPathEqualTo("/auth/login"))
+        .withQueryParam("id", equalTo("tester"))
+        .withQueryParam("apiKey", equalTo(API_KEY))
+        .willReturn(aResponse().withStatus(200).withHeader(HttpHeaderNames.CONTENT_TYPE.toString(),
+            HttpHeaderValues.APPLICATION_JSON.toString())
+            .withBody(AUTH_SERVICE_RESPONSE.toString())));
+    authServiceServer.start();
+  }
+
+  private void setUpDatabaseServer(int servicePort) {
+    WireMockServer databaseServiceServer = new WireMockServer(servicePort);
+    databaseServiceServer.stubFor(post(urlEqualTo("/database/manage"))
+        .withRequestBody(equalToJson(SERVICE_B_REQUIRED_BODY.toString()))
+        .willReturn(aResponse().withStatus(200).withHeader(HttpHeaderNames.CONTENT_TYPE.toString(),
+            HttpHeaderValues.APPLICATION_JSON.toString())
+            .withBody(DATABASE_SERVICE_RESPONSE.toString())));
+    databaseServiceServer.start();
+  }
+
+  private void setUpServerTester(Integer globalServerPort) {
+    serverTester = KnotxServerTester.defaultInstance(globalServerPort);
+  }
+
+  private void shouldReturnValidResponse(HttpResponse<Buffer> response) {
+    assertEquals(HttpResponseStatus.OK.code(), response.statusCode());
+    JsonObject responseJson = response.bodyAsJsonObject();
+    assertNotNull(responseJson);
+
+    JsonObject databaseActionData = responseJson.getJsonObject("reload-database");
+    JsonObject databaseServiceResponse = databaseActionData.getJsonObject("_result");
+
+    assertEquals(DATABASE_SERVICE_RESPONSE, databaseServiceResponse);
+  }
+
+  private String encodedApiKey() throws UnsupportedEncodingException {
+    return URLEncoder.encode(API_KEY, StandardCharsets.UTF_8.name());
+  }
+
+}

--- a/src/functionalTest/java/io/knotx/stack/functional/VariousMethodsForHttpActionIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/VariousMethodsForHttpActionIntegrationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.stack.functional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.RandomPort;
+import io.knotx.stack.KnotxServerTester;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KnotxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+class VariousMethodsForHttpActionIntegrationTest {
+
+  private static final String REQUEST_BODY = "{\"password\": \"pazzword\"}";
+
+  private WireMockServer serviceServer;
+  private KnotxServerTester serverTester;
+
+  @AfterEach
+  void tearDown() {
+    serviceServer.stop();
+  }
+
+  @Test
+  @DisplayName("Expect various HTTP methods to be supported by HttpAction")
+  @KnotxApplyConfiguration({"conf/application.conf",
+      "scenarios/various-methods-for-http-action/mocks.conf",
+      "scenarios/various-methods-for-http-action/tasks.conf"})
+  void taskWithManyHttpMethods(VertxTestContext context, Vertx vertx,
+      @RandomPort Integer servicePort, @RandomPort Integer globalServerPort) {
+    // given
+    setUpServiceServer(servicePort);
+    setUpServerTester(globalServerPort);
+
+    // when, then
+    serverTester
+        .testGetRequest(context, vertx, "/content/variousHttpMethods.html",
+            "scenarios/various-methods-for-http-action/result/fullPage.html");
+  }
+
+  private void setUpServiceServer(int servicePort) {
+    serviceServer = new WireMockServer(servicePort);
+    // get
+    serviceServer.stubFor(get(urlEqualTo("/service/mock/get.json"))
+        .willReturn(response200Json(responseBodyFor("GET"))));
+    // post
+    serviceServer.stubFor(post(urlEqualTo("/service/mock/post.json"))
+        .withRequestBody(equalToJson(REQUEST_BODY))
+        .willReturn(response200Json(responseBodyFor("POST"))));
+    // put
+    serviceServer.stubFor(put(urlEqualTo("/service/mock/put.json"))
+        .withRequestBody(equalToJson(REQUEST_BODY))
+        .willReturn(response200Json(responseBodyFor("PUT"))));
+    // patch
+    serviceServer.stubFor(patch(urlEqualTo("/service/mock/patch.json"))
+        .withRequestBody(equalToJson(REQUEST_BODY))
+        .willReturn(response200Json(responseBodyFor("PATCH"))));
+    // delete
+    serviceServer.stubFor(delete(urlEqualTo("/service/mock/delete.json"))
+        .willReturn(response200Json(responseBodyFor("DELETE"))));
+    // head
+    serviceServer.stubFor(head(urlEqualTo("/service/mock/head.json"))
+        .willReturn(response200()));
+    serviceServer.start();
+  }
+
+  private void setUpServerTester(Integer globalServerPort) {
+    serverTester = KnotxServerTester.defaultInstance(globalServerPort);
+  }
+
+  private String responseBodyFor(String type) {
+    return new JsonObject().put("type", type).toString();
+  }
+
+  private ResponseDefinitionBuilder response200Json(String responseBody) {
+    return response200().withHeader(HttpHeaderNames.CONTENT_TYPE.toString(),
+        HttpHeaderValues.APPLICATION_JSON.toString()).withBody(responseBody);
+  }
+
+  private ResponseDefinitionBuilder response200() {
+    return aResponse().withStatus(200);
+  }
+}

--- a/src/functionalTest/resources/content/variousHttpMethods.html
+++ b/src/functionalTest/resources/content/variousHttpMethods.html
@@ -1,0 +1,58 @@
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/4/simplex/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="jumbotron">
+        <h2>
+          Hello Knot.x - reactive micro-service assembler world!
+        </h2>
+        <p>
+          This template is served from the <strong>local</strong> repository.
+        </p>
+        <p>
+          <a class="btn btn-primary btn-large"
+             href="https://github.com/Knotx/knotx">Learn more</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <knotx:snippet data-knotx-task="various-methods-for-http-action">
+      <ul>
+        <li>GET: {{ get._response.metadata.statusCode }} : {{ get._result.type }}</li>
+        <li>POST: {{ post._response.metadata.statusCode }} : {{ post._result.type }}</li>
+        <li>PUT: {{ put._response.metadata.statusCode }} : {{ put._result.type }}</li>
+        <li>PATCH: {{ patch._response.metadata.statusCode }} : {{ patch._result.type }}</li>
+        <li>DELETE: {{ delete._response.metadata.statusCode }} : {{ delete._result.type }}</li>
+        <li>HEAD: {{ head._response.metadata.statusCode }}</li>
+      </ul>
+    </knotx:snippet>
+  </div>
+</div>
+</body>
+</html>

--- a/src/functionalTest/resources/scenarios/dependent-http-actions-scenario-test/mocks.conf
+++ b/src/functionalTest/resources/scenarios/dependent-http-actions-scenario-test/mocks.conf
@@ -1,0 +1,9 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}
+test.random {
+  authService.port = 0
+  databaseService.port = 0
+}

--- a/src/functionalTest/resources/scenarios/dependent-http-actions-scenario-test/tasks.conf
+++ b/src/functionalTest/resources/scenarios/dependent-http-actions-scenario-test/tasks.conf
@@ -1,0 +1,70 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    web-api-test {
+      action = obtain-auth-token
+      onTransitions._success {
+        action = reload-database
+        onTransitions {
+          _success {
+            action = create-response
+          }
+        }
+      }
+    }
+  }
+
+  actions {
+    obtain-auth-token {
+      factory = http
+      config {
+        endpointOptions {
+          path = "/auth/login?id={param.id}&apiKey={param.key}"
+          domain = localhost
+          port = ${test.random.authService.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+        responseOptions.predicates = [ JSON ]
+      }
+    }
+    reload-database {
+      factory = http
+      config {
+        httpMethod = POST
+        endpointOptions {
+          path = /database/manage
+          domain = localhost
+          port = ${test.random.databaseService.port}
+          interpolateBody = true
+          bodyJson {
+            id = "{param.id}"
+            authToken = "{payload.obtain-auth-token._result.token}"
+            operation = reloadFromPermanentStorage
+          }
+          allowedRequestHeaders = ["Content-Type"]
+        }
+        responseOptions.predicates = [ JSON ]
+      }
+    }
+    create-response {
+      factory = payload-to-body
+    }
+  }
+
+  taskFactories = [
+    {
+      factory = default
+      config {
+        tasks = ${global.handler.fragmentsHandler.config.tasks}
+        nodeFactories = [
+          {
+            factory = action
+            config.actions = ${global.handler.fragmentsHandler.config.actions}
+          }
+          {
+            factory = subtasks
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/functionalTest/resources/scenarios/various-methods-for-http-action/mocks.conf
+++ b/src/functionalTest/resources/scenarios/various-methods-for-http-action/mocks.conf
@@ -1,0 +1,8 @@
+########### Knot.x JUnit5 config ###########
+test.wiremock {
+  mockRepository.port = 0
+  mockService.port = 0
+}
+test.random {
+  service.port = 0
+}

--- a/src/functionalTest/resources/scenarios/various-methods-for-http-action/result/fullPage.html
+++ b/src/functionalTest/resources/scenarios/various-methods-for-http-action/result/fullPage.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright (C) 2019 Knot.x Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/superhero/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="jumbotron">
+          <h2> Hello Knot.x - reactive micro-service assembler world! </h2>
+          <p> This template is served from the <strong>local</strong> repository. </p>
+          <p> <a class="btn btn-primary btn-large" href="https://github.com/Knotx/knotx">Learn more</a> </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <ul>
+        <li>GET: 200 : GET</li>
+        <li>POST: 200 : POST</li>
+        <li>PUT: 200 : PUT</li>
+        <li>PATCH: 200 : PATCH</li>
+        <li>DELETE: 200 : DELETE</li>
+        <li>HEAD: 200</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/functionalTest/resources/scenarios/various-methods-for-http-action/tasks.conf
+++ b/src/functionalTest/resources/scenarios/various-methods-for-http-action/tasks.conf
@@ -1,0 +1,140 @@
+global.handler.fragmentsHandler.config {
+  tasks {
+    various-methods-for-http-action {
+      actions = [
+        {
+          action = get
+        }
+        {
+          action = post
+        }
+        {
+          action = put
+        }
+        {
+          action = patch
+        }
+        {
+          action = delete
+        }
+        {
+          action = head
+        }
+      ]
+      onTransitions._success {
+        action = te-hbs
+      }
+    }
+  }
+
+  actions {
+    get {
+      factory = http
+      config {
+        httpMethod = get
+        endpointOptions {
+          path = /service/mock/get.json
+          domain = localhost
+          port = ${test.random.service.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+        responseOptions {
+          forceJson = true
+        }
+      }
+    }
+    post {
+      factory = http
+      config {
+        httpMethod = post
+        endpointOptions {
+          path = /service/mock/post.json
+          body = "{\"password\": \"pazzword\"}"
+          domain = localhost
+          port = ${test.random.service.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    put {
+      factory = http
+      config {
+        httpMethod = put
+        endpointOptions {
+          path = /service/mock/put.json
+          interpolateBody = true
+          bodyJson {
+            password = pazzword
+          }
+          domain = localhost
+          port = ${test.random.service.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    patch {
+      factory = http
+      config {
+        httpMethod = patch
+        endpointOptions {
+          path = /service/mock/patch.json
+          body = "{\"password\": \"pazzword\"}"
+          domain = localhost
+          port = ${test.random.service.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    delete {
+      factory = http
+      config {
+        httpMethod = delete
+        endpointOptions {
+          path = /service/mock/delete.json
+          domain = localhost
+          port = ${test.random.service.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    head {
+      factory = http
+      config {
+        httpMethod = head
+        endpointOptions {
+          path = /service/mock/head.json
+          domain = localhost
+          port = ${test.random.service.port}
+          allowedRequestHeaders = ["Content-Type"]
+        }
+      }
+    }
+    te-hbs {
+      factory = knot
+      config {
+        address = knotx.knot.te.handlebars
+        deliveryOptions {
+          sendTimeout = 3000
+        }
+      }
+    }
+  }
+
+  taskFactories = [
+    {
+      factory = default
+      config {
+        tasks = ${global.handler.fragmentsHandler.config.tasks}
+        nodeFactories = [
+          {
+            factory = action
+            config.actions = ${global.handler.fragmentsHandler.config.actions}
+          }
+          {
+            factory = subtasks
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Provide unit testing for newly supported HTTP methods.

## Description
This PR consists of two functional tests:

- one testing a simple call to a mock server with each supported method
- one presenting a service call with POST request body composed using a response from another service

## Motivation and Context
Knotx/knotx-fragments#73

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
