### PR TITLE
Functional tests for enable passing status code from handlers to end user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-114](https://github.com/Knotx/knotx-stack/pull/114) - Knotx/knotx-fragments#161 enable passing status code from handlers to end user
                 
 ## 2.2.0
 - [PR-110](https://github.com/Knotx/knotx-stack/pull/110) - Knotx/knotx-fragments#154 Fragments modules refactor.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     testImplementation(group = "io.vertx", name = "vertx-unit")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(group = "io.vertx", name = "vertx-web-client")
     testImplementation(group = "com.github.tomakehurst", name = "wiremock")
     testImplementation(group = "io.rest-assured", name = "rest-assured", version = "3.3.0")
 
@@ -90,6 +91,7 @@ dependencies {
     functionalTestImplementation("org.junit.jupiter:junit-jupiter-api")
     functionalTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     functionalTestImplementation(group = "com.github.tomakehurst", name = "wiremock")
+    functionalTestImplementation(group = "io.vertx", name = "vertx-web-client")
 }
 
 tasks {

--- a/src/functionalTest/java/io/knotx/stack/functional/FailedKnotxFragmentScenarioTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/FailedKnotxFragmentScenarioTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
-import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,9 +88,9 @@ public class FailedKnotxFragmentScenarioTest {
   void requestFailedDataWithHeader(VertxTestContext testContext, Vertx vertx, @RandomPort Integer delayedServicePort, @RandomPort Integer globalServerPort) {
     prepareServer(delayedServicePort, globalServerPort);
 
-    Map<String, String> headers = Collections.singletonMap("Allow-Invalid-Fragments", "true");
-
-    serverTester.testGet(testContext, vertx, "/content/failedFragment.html", headers, response -> {
+    serverTester
+        .withRequestHeaders(Collections.singletonMap("Allow-Invalid-Fragments", "true"))
+        .testGet(testContext, vertx, "/content/failedFragment.html", response -> {
       assertEquals(200, response.statusCode());
     });
   }

--- a/src/functionalTest/java/io/knotx/stack/functional/FailingHttpServicesWithFallbacksIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/FailingHttpServicesWithFallbacksIntegrationTest.java
@@ -67,7 +67,7 @@ class FailingHttpServicesWithFallbacksIntegrationTest {
 
     KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
     serverTester
-        .testGetRequest(context, vertx, "/content/fullPage.html",
+        .testGetWithExpectedResponse(context, vertx, "/content/fullPage.html",
             "scenarios/failing-http-services-with-fallbacks/result/fullPage.html");
   }
 }

--- a/src/functionalTest/java/io/knotx/stack/functional/LongRunningHttpServiceWithCircuitBreakerIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/LongRunningHttpServiceWithCircuitBreakerIntegrationTest.java
@@ -73,7 +73,7 @@ class LongRunningHttpServiceWithCircuitBreakerIntegrationTest {
     // when
     KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
     serverTester
-        .testGetRequest(context, vertx, "/content/fullPage.html",
+        .testGetWithExpectedResponse(context, vertx, "/content/fullPage.html",
             "scenarios/long-running-http-service-with-circuit-breaker/result/fullPage.html");
   }
 

--- a/src/functionalTest/java/io/knotx/stack/functional/PebbleTemplateEngineIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/PebbleTemplateEngineIntegrationTest.java
@@ -42,7 +42,7 @@ class PebbleTemplateEngineIntegrationTest {
       @RandomPort Integer globalServerPort) {
     // when
     KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
-    serverTester.testGetRequest(context, vertx,
+    serverTester.testGetWithExpectedResponse(context, vertx,
         "/content/fullPebblePage.html", "results/fullPage.html");
   }
 }

--- a/src/functionalTest/java/io/knotx/stack/functional/RepositoryConnectorRedirectPassedToEndUserTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/RepositoryConnectorRedirectPassedToEndUserTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.stack.functional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.RandomPort;
+import io.knotx.stack.KnotxServerTester;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KnotxExtension.class)
+class RepositoryConnectorRedirectPassedToEndUserTest {
+
+  private WireMockServer httpRepositoryServer;
+
+
+
+  @Test
+  @DisplayName("Should return redirect response when Http Repository returns redirect with empty body (AEM author login redirect case)")
+  @KnotxApplyConfiguration({"conf/application.conf",
+      "common/templating/routing.conf",
+      "common/templating/fragments.conf",
+      "scenarios/repository-connector-redirect-passed-to-end-user/httpRepoConnectorHandler.conf",
+      "scenarios/repository-connector-redirect-passed-to-end-user/mocks.conf"})
+  void requestAemAuthorResourceLoginRedirect(VertxTestContext testContext, Vertx vertx,
+      @RandomPort Integer httpRepositoryPort, @RandomPort Integer globalServerPort) {
+    httpRepositoryServer = new WireMockServer(httpRepositoryPort);
+    httpRepositoryServer.stubFor(get(urlEqualTo("/admin-panel.html")).willReturn(
+        aResponse()
+            .withStatus(HttpResponseStatus.FOUND.code())
+            .withHeader("location", "/login.html")));
+    httpRepositoryServer.start();
+
+    KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
+    serverTester
+        .withClientOptions(new WebClientOptions().setFollowRedirects(false))
+        .testGet(testContext, vertx, "/admin-panel.html",
+        resp -> {
+          assertEquals(HttpResponseStatus.FOUND.code(), resp.statusCode());
+          assertEquals("/login.html", resp.getHeader("location"));
+        });
+  }
+
+  @Test
+  @DisplayName("Should return not-found response when Http Repository returns 404 with empty body (AEM author login redirect case)")
+  @KnotxApplyConfiguration({"conf/application.conf",
+      "common/templating/routing.conf",
+      "common/templating/fragments.conf",
+      "scenarios/repository-connector-redirect-passed-to-end-user/httpRepoConnectorHandler.conf",
+      "scenarios/repository-connector-redirect-passed-to-end-user/mocks.conf"})
+  void requestRepositoryGetNotFound(VertxTestContext testContext, Vertx vertx,
+      @RandomPort Integer httpRepositoryPort, @RandomPort Integer globalServerPort) {
+    httpRepositoryServer = new WireMockServer(httpRepositoryPort);
+    httpRepositoryServer.stubFor(get(urlEqualTo("/not-existing.html")).willReturn(
+        aResponse()
+            .withStatus(HttpResponseStatus.NOT_FOUND.code()))
+    );
+    httpRepositoryServer.start();
+
+    KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
+    serverTester.testGet(testContext, vertx, "/not-existing.html",
+        resp -> {
+          assertEquals(HttpResponseStatus.NOT_FOUND.code(), resp.statusCode());
+        });
+  }
+
+  @AfterEach
+  void tearDown() {
+    httpRepositoryServer.stop();
+  }
+}

--- a/src/functionalTest/java/io/knotx/stack/functional/TemplateEnginesIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/TemplateEnginesIntegrationTest.java
@@ -39,7 +39,7 @@ class TemplateEnginesIntegrationTest {
   void requestPage(VertxTestContext testContext, Vertx vertx,
       @RandomPort Integer globalServerPort) {
     KnotxServerTester serverTester = KnotxServerTester.defaultInstance(globalServerPort);
-    serverTester.testGetRequest(testContext, vertx, "/content/payments.html",
+    serverTester.testGetWithExpectedResponse(testContext, vertx, "/content/payments.html",
         "scenarios/template-engines-integration/resultPage.html");
   }
 }

--- a/src/functionalTest/java/io/knotx/stack/functional/VariousMethodsForHttpActionIntegrationTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/VariousMethodsForHttpActionIntegrationTest.java
@@ -72,7 +72,7 @@ class VariousMethodsForHttpActionIntegrationTest {
 
     // when, then
     serverTester
-        .testGetRequest(context, vertx, "/content/variousHttpMethods.html",
+        .testGetWithExpectedResponse(context, vertx, "/content/variousHttpMethods.html",
             "scenarios/various-methods-for-http-action/result/fullPage.html");
   }
 

--- a/src/functionalTest/resources/conf/server.conf
+++ b/src/functionalTest/resources/conf/server.conf
@@ -38,6 +38,7 @@ config.server {
           Content-Type
           Content-Length
           X-Server
+          Location
         ]
       }
     ]

--- a/src/functionalTest/resources/scenarios/repository-connector-redirect-passed-to-end-user/httpRepoConnectorHandler.conf
+++ b/src/functionalTest/resources/scenarios/repository-connector-redirect-passed-to-end-user/httpRepoConnectorHandler.conf
@@ -1,0 +1,32 @@
+global.handler.httpRepoConnectorHandler.config {
+  clientOptions {
+    maxPoolSize = 1000
+    idleTimeout = 120
+    tryUseCompression = true
+    # do not follow redirects to pass it to the end user
+    followRedirects = false
+  }
+
+  clientDestination {
+    scheme = http
+    domain = localhost
+    port = ${test.random.httpRepository.port}
+  }
+
+  allowedRequestHeaders = [
+    "Accept.*"
+    Authorization
+    Connection
+    Cookie
+    Date
+    "Edge.*"
+    "If.*"
+    Origin
+    Pragma
+    Proxy-Authorization
+    "Surrogate.*"
+    User-Agent
+    Via
+    "X-.*"
+  ]
+}

--- a/src/functionalTest/resources/scenarios/repository-connector-redirect-passed-to-end-user/mocks.conf
+++ b/src/functionalTest/resources/scenarios/repository-connector-redirect-passed-to-end-user/mocks.conf
@@ -1,0 +1,4 @@
+########### Knot.x JUnit5 config ###########
+test.random {
+  httpRepository.port = 0
+}

--- a/src/main/packaging/conf/server.conf
+++ b/src/main/packaging/conf/server.conf
@@ -30,6 +30,7 @@ config.server {
           Access-Control-Allow-Origin
           Content-Type
           Content-Length
+          Location
         ]
       }
     ]


### PR DESCRIPTION
## Description
Functional tests for enable passing status code from handlers to end user

## Motivation and Context
https://github.com/Knotx/knotx-fragments/issues/161

## Upgrade notes
`Location` header was added to the default server `allowedResponseHeaders` configuration so that it will be passed together with redirect status codes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
