### PR TITLE
Run Fragments Task Functional tests with stack functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-115](https://github.com/Knotx/knotx-stack/pull/115) - knotx-fragments-task-functional-test are executed during stack functional tests 
                 
 ## 2.2.0
 - [PR-110](https://github.com/Knotx/knotx-stack/pull/110) - Knotx/knotx-fragments#154 Fragments modules refactor.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     functionalTestImplementation("org.junit.jupiter:junit-jupiter-api")
     functionalTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     functionalTestImplementation(group = "com.github.tomakehurst", name = "wiremock")
+    functionalTestImplementation("io.knotx:knotx-fragments-task-functional-test:${project.version}")
 }
 
 tasks {
@@ -101,6 +102,9 @@ tasks {
         testClassesDirs = sourceSets["functionalTest"].output.classesDirs
 
         shouldRunAfter("test")
+        if (file(".composite-enabled").exists()) {
+            dependsOn(gradle.includedBuild("knotx-fragments").task(":knotx-fragments-task-functional-test:test"))
+        }
     }
 
     named("check") { dependsOn("functionalTest") }


### PR DESCRIPTION
## Description
Functional tests from `knotx-fragments-task-functional-test` module are not executed during stack build while all included builds are.

## Motivation and Context
When stack is built all modules and tests should be executed.
This could also cause https://github.com/Knotx/knotx-aggregator/issues/37

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
