### PR TITLE
Execute tests from all included knotx-stack builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,10 @@ tasks {
         shouldRunAfter("test")
     }
 
-    named("check") { dependsOn("functionalTest") }
+    named("check") {
+        dependsOn("functionalTest")
+        dependsOn(gradle.includedBuilds.stream().map { ib -> ib.task(":check") }.toArray())
+    }
 
     named("build") {
         if (file(".composite-enabled").exists()) {


### PR DESCRIPTION
## Description
Add support for running tests for each composite-build modules tests. Apply plugin `composite-build-support` (renamed `publish-all-composite`).

## Motivation and Context
https://github.com/Knotx/knotx-stack/issues/57

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.