### PR TITLE
Upgrade to Vert.x 3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to `knotx-stack` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-                
+- [PR-118](https://github.com/Knotx/knotx-template-engine/pull/118) - Upgrade to Vert.x `3.9.1` - removed `netty-tcnative` as TLS ALPN support has been back-ported to JDK 8.
+
 ## 2.2.1
 - [PR-114](https://github.com/Knotx/knotx-stack/pull/114) - Knotx/knotx-fragments#161 enable passing status code from handlers to end user
                 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,6 @@ dependencies {
     implementation("io.knotx:knotx-template-engine-core:${project.version}")
     implementation("io.knotx:knotx-template-engine-handlebars:${project.version}")
     implementation("io.knotx:knotx-template-engine-pebble:${project.version}")
-    implementation("io.netty:netty-tcnative-boringssl-static")
 
     testImplementation("io.knotx:knotx-junit5:${project.version}")
     testImplementation(group = "io.vertx", name = "vertx-junit5")


### PR DESCRIPTION
## Description
Upgrade Vert.x to 3.9.1

## Motivation and Context
https://github.com/Knotx/knotx-dependencies/issues/48

## Upgrade notes (if appropriate)
- TLS ALPN support has been back-ported to JDK 8 recently and Vert.x has been upgraded to support it which means now you can have HTTP/2 on JDK 8 out of the box. `netty-tcnative` was removed from stack dependencies. If your Knot.x image does not base on newer version of JDK 8, you may need to add `io.netty:netty-tcnative-boringssl-static` to the classpath in order to use HTTP/2. See https://github.com/eclipse-vertx/vert.x/issues/3391 for details.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
