### PR TITLE
Fixing IDEA issue with functional tests classpath resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,8 @@ repositories {
 
 sourceSets {
     register("functionalTest") {
-        compileClasspath += sourceSets.test.get().output.classesDirs
-        runtimeClasspath += sourceSets.test.get().output.classesDirs
+        compileClasspath += sourceSets.test.get().output
+        runtimeClasspath += sourceSets.test.get().output
     }
     test {
         resources {


### PR DESCRIPTION
<!-- Please update the sections below that apply, remove the rest -->

## Description
After importing `knotx-stack` into IDEA, there is a problem with importing` KnotxServerTester`. Gradle compilation works fine. 

After this modification, IntelliJ can see `KnotxServerTester` without issues.

## Motivation and Context
Run tests from IDE.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
