### PR TITLE
Knotx/knotx-fragments#180 Fragment debug data scenarion unification.

### DIFF
--- a/src/functionalTest/resources/scenarios/fragments-debug-data/mocks.conf
+++ b/src/functionalTest/resources/scenarios/fragments-debug-data/mocks.conf
@@ -3,5 +3,6 @@ test.wiremock {
   mockService.port = 0
 }
 test.random {
+  brokenService.port = 0
   delayedService.port = 0
 }

--- a/src/functionalTest/resources/scenarios/fragments-debug-data/tasks.conf
+++ b/src/functionalTest/resources/scenarios/fragments-debug-data/tasks.conf
@@ -1,11 +1,13 @@
 global.handler.fragmentsHandler.config {
   tasks {
+    # HTML Templating Scenario
     user-task {
       action = fetch-user-info // _success
       onTransitions._success {
         action = te-hbs
       }
     }
+    # HTML Templating Scenario
     payments-task {
       action = fetch-user-info // _success
       onTransitions._success {
@@ -23,9 +25,15 @@ global.handler.fragmentsHandler.config {
             }
           }
           {
-            action = fetch-delivery-options-cb // _fallback
+            action = fetch-delivery-options-cb // 2 x 500 -> _fallback
             onTransitions._fallback {
-              action = fetch-delivery-timeout // _success
+              action = fetch-delivery-fallback // _success
+            }
+          }
+          {
+            action = notify-analytics-cb // 2 x timeout -> _fallback
+            onTransitions._fallback {
+              action = notify-analytics-fallback // _success
             }
           }
         ]
@@ -35,36 +43,27 @@ global.handler.fragmentsHandler.config {
       }
       onTransitions._error {
         action = fetch-user-info-fallback
-        onTransitions._success {
-          action = fetch-user-info-fallback-success
-        }
-        onTransitions._error {
-          action = fetch-user-info-fallback-error
-        }
       }
       onTransitions._custom {
-        action = fetch-user-info-custom-fallback
+        action = fetch-user-info-custom
       }
     }
-    web-api-test {
-      action = fetch-user-info
-      onTransitions._success {
-        actions = [
-          {
-            action = fetch-payment-providers
-          }
-          {
-            action = fetch-offers-json
-          }
-        ]
-        onTransitions._success {
-          action = create-response
-        }
-      }
-    }
+    # Web API Scenario
+    web-api-test = ${global.handler.fragmentsHandler.config.tasks.payments-task}
+    web-api-test.onTransitions._success.onTransitions._success.action = create-response // _success
   }
 
   actions {
+    common-fallback-action {
+      factory = http
+      config.endpointOptions {
+        path = /service/mock/placeholderFallback.json
+        domain = localhost
+        port = ${test.wiremock.mockService.port}
+        allowedRequestHeaders = ["Content-Type"]
+      }
+    }
+
     fetch-user-info {
       factory = http
       config.endpointOptions {
@@ -74,6 +73,7 @@ global.handler.fragmentsHandler.config {
         allowedRequestHeaders = ["Content-Type"]
       }
     }
+
     fetch-payment-providers {
       factory = http
       config.endpointOptions {
@@ -83,6 +83,7 @@ global.handler.fragmentsHandler.config {
         allowedRequestHeaders = ["Content-Type"]
       }
     }
+
     fetch-offers {
       factory = http
       config.endpointOptions {
@@ -96,7 +97,7 @@ global.handler.fragmentsHandler.config {
         predicates = []
       }
     }
-    fetch-offers-json {
+    fetch-offers-fallback {
       factory = http
       config.endpointOptions {
         path = /service/mock/specialOffers.json
@@ -106,15 +107,6 @@ global.handler.fragmentsHandler.config {
       }
     }
 
-    fetch-delivery {
-      factory = http
-      config.endpointOptions {
-        path = /mock/scenario/delayed
-        domain = localhost
-        port = ${test.random.delayedService.port}
-        allowedRequestHeaders = ["Content-Type"]
-      }
-    }
     fetch-delivery-options-cb {
       factory = cb
       config {
@@ -126,18 +118,16 @@ global.handler.fragmentsHandler.config {
       }
       doAction = fetch-delivery
     }
-    fetch-offers-fallback {
-      factory = inline-payload
-      config {
-        alias = fetch-offers
-        payload {
-          _result {
-            fallback = "json-syntax-error"
-          }
-        }
+    fetch-delivery {
+      factory = http
+      config.endpointOptions {
+        path = /mock/scenario/delayed
+        domain = localhost
+        port = ${test.random.delayedService.port}
+        allowedRequestHeaders = ["Content-Type"]
       }
     }
-    fetch-delivery-timeout {
+    fetch-delivery-fallback {
       factory = inline-payload
       config {
         alias = fetch-delivery
@@ -148,50 +138,32 @@ global.handler.fragmentsHandler.config {
         }
       }
     }
-    fetch-payment-providers-fallback {
+
+    notify-analytics-cb {
+      factory = cb
+      config {
+        circuitBreakerName = delivery-cb
+      }
+      doAction = notify-analytics
+    }
+    notify-analytics {
       factory = http
+      config.httpMethod = POST
       config.endpointOptions {
-        path = /service/mock/placeholderFallback.json
+        path = /mock/scenario/analytics
         domain = localhost
-        port = ${test.wiremock.mockService.port}
+        port = ${test.random.brokenService.port}
+        bodyJson = {
+          user-data-id = "{payload.fetch-user-info._result.id}"
+        }
+        interpolateBody = true
         allowedRequestHeaders = ["Content-Type"]
       }
     }
-    fetch-user-info-fallback {
-      factory = http
-      config.endpointOptions {
-        path = /service/mock/placeholderFallback.json
-        domain = localhost
-        port = ${test.wiremock.mockService.port}
-        allowedRequestHeaders = ["Content-Type"]
-      }
-    }
-    fetch-user-info-fallback-success {
-      factory = http
-      config.endpointOptions {
-        path = /service/mock/placeholderFallback.json
-        domain = localhost
-        port = ${test.wiremock.mockService.port}
-        allowedRequestHeaders = ["Content-Type"]
-      }
-    }
-    fetch-user-info-fallback-error {
-      factory = http
-      config.endpointOptions {
-        path = /service/mock/placeholderFallback.json
-        domain = localhost
-        port = ${test.wiremock.mockService.port}
-        allowedRequestHeaders = ["Content-Type"]
-      }
-    }
-    fetch-user-info-custom-fallback {
-      factory = http
-      config.endpointOptions {
-        path = /service/mock/placeholderFallback.json
-        domain = localhost
-        port = ${test.wiremock.mockService.port}
-        allowedRequestHeaders = ["Content-Type"]
-      }
-    }
+    notify-analytics-fallback = ${global.handler.fragmentsHandler.config.actions.common-fallback-action}
+
+    fetch-payment-providers-fallback = ${global.handler.fragmentsHandler.config.actions.common-fallback-action}
+    fetch-user-info-fallback = ${global.handler.fragmentsHandler.config.actions.common-fallback-action}
+    fetch-user-info-custom = ${global.handler.fragmentsHandler.config.actions.common-fallback-action}
   }
 }


### PR DESCRIPTION
Closes Knotx/knotx-fragments#180.

## Description
- reuse the same configuration for templating and web api scenarios.
- provide two separate scenarios for error handling - 
  - API responds with 500
  - API does not respond on time

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
