### PR TITLE
knotx/knotx-fragments#219 update wiremock dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     functionalTestImplementation(group = "io.vertx", name = "vertx-rx-java2")
     functionalTestImplementation("org.junit.jupiter:junit-jupiter-api")
     functionalTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    functionalTestImplementation(group = "com.github.tomakehurst", name = "wiremock")
+    functionalTestImplementation(group = "com.github.tomakehurst", name = "wiremock-jre8")
     functionalTestImplementation(group = "io.vertx", name = "vertx-web-client")
 }
 

--- a/src/functionalTest/java/io/knotx/stack/functional/CircuitBreakerTimesOutScenarioTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/CircuitBreakerTimesOutScenarioTest.java
@@ -18,7 +18,7 @@ package io.knotx.stack.functional;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/src/functionalTest/java/io/knotx/stack/functional/DependentHttpActionsScenarioTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/DependentHttpActionsScenarioTest.java
@@ -22,8 +22,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.knotx.junit5.KnotxApplyConfiguration;

--- a/src/functionalTest/java/io/knotx/stack/functional/HttpServiceRespondsWithInvalidJsonScenarioTest.java
+++ b/src/functionalTest/java/io/knotx/stack/functional/HttpServiceRespondsWithInvalidJsonScenarioTest.java
@@ -15,9 +15,9 @@
  */
 package io.knotx.stack.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.knotx.junit5.KnotxApplyConfiguration;
 import io.knotx.junit5.KnotxExtension;


### PR DESCRIPTION
Fixes Knotx/knotx-fragments#219.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
